### PR TITLE
fix: Improve inverse transform

### DIFF
--- a/saiph/projection_test.py
+++ b/saiph/projection_test.py
@@ -387,7 +387,7 @@ def test_get_random_weighted_columns(weights: List[float], expected_index: int):
 
 
 # wider than len df
-def test_inverse_transform_raises_value_error() -> None:
+def test_inverse_transform_raises_value_error_when_wider_than_df() -> None:
     wider_df = pd.DataFrame(
         {
             "variable_1": ["a", "b", "c"],
@@ -395,5 +395,5 @@ def test_inverse_transform_raises_value_error() -> None:
         }
     )
     coord, model = fit(wider_df)
-    with pytest.raises(ValueError, match="Inverse transform may lead to bias. "):
+    with pytest.raises(ValueError, match=r"n_dimensions"):
         inverse_transform(coord, model)


### PR DESCRIPTION
resolves #26 and improve inverse transform

multiple operations have been gathered in one. We get back scaled_df directly no matter projection type. 

This PR add pultiple fix:
- return error if n_dimension > N unless you specified (approximate = True)
- approximate a matrix if the user wants to inverse transform anyway 
- highly improve the drift linked to the use of weights in a context where n_dim > N (however the approximation is mathematically unavoidable so a bias persists)
- allow the user to choose if the reverse transform will be determinitic or not for categorical variables 

Lets take the example of the following dummy categorical df obtain after discaling:

cat__a, cat__b, cat__c
0.1        0.2        0.7
0.3       0.4        0.3
0.1        0.9        0

if deterministic = True, inverse transform will always return c, b, b according to max modality
else the result will depend on random with ponderations following proportions

NOTE: We might want to set determinitic to False for inverse transform in avatarize.