### PR TITLE
fix: remove one dummy for bimodal vars in MCA

### DIFF
--- a/saiph/inverse_transform.py
+++ b/saiph/inverse_transform.py
@@ -90,6 +90,8 @@ def inverse_transform(
         )
         descaled_values_quali = inverse_coord_quali.divide(model.dummies_col_prop)
 
+        print('model.dummy_categorical: ', model.dummy_categorical)
+        print('model.dropped_categories: ', model.dropped_categories)
         inverse = undummify(
             descaled_values_quali,
             get_dummies_mapping(model.original_categorical, model.dummy_categorical),
@@ -147,7 +149,10 @@ def undummify(
 
         extra_col = None
         if dropped_categories:
-            extra_col = [c for c in dropped_categories if c.startswith(original_column+DUMMIES_PREFIX_SEP)][0]
+            tmp = [c for c in dropped_categories if c.startswith(original_column+DUMMIES_PREFIX_SEP)]
+            extra_col = None
+            if len(tmp) > 0:
+                extra_col = tmp[0]
         if extra_col:
             single_category[extra_col] =  1 - single_category.sum(axis="columns")
 

--- a/saiph/inverse_transform_test.py
+++ b/saiph/inverse_transform_test.py
@@ -58,6 +58,39 @@ def test_undummify(
     )
 
     df = undummify(dummy_df, mapping, use_max_modalities=use_max_modalities, seed=321)
+    print('undummified_df: ', df)
+
+    assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize(
+    "use_max_modalities, expected",
+    [
+        (
+            True,
+            pd.DataFrame(
+                [["wrench", "orange"], ["hammer", "apple"]], columns=["tool", "fruit"]
+            ),
+        ),
+        (
+            False,
+            pd.DataFrame(
+                [["wrench", "orange"], ["wrench", "apple"]], columns=["tool", "fruit"]
+            ),
+        ),
+    ],
+)
+def test_undummify_dropped_modality(
+    mapping: Dict[str, List[str]], use_max_modalities: bool, expected: pd.DataFrame
+) -> None:
+    """Test undummify a disjunctive table with different use_max_modalities."""
+    dummy_df = pd.DataFrame(
+        [[0.3, 0.99], [0.51, 0.2]],
+        columns=["tool___hammer", "fruit___orange"],
+    )
+
+    df = undummify(dummy_df, mapping, use_max_modalities=use_max_modalities, seed=321)
+    print('undummified_df: ', df)
 
     assert_frame_equal(df, expected)
 

--- a/saiph/models.py
+++ b/saiph/models.py
@@ -68,3 +68,6 @@ class Model:
     cos2: Optional[pd.DataFrame] = None
     # Proportion of individuals taking each modality.
     dummies_col_prop: Optional[NDArray[np.float_]] = None  # MCA only
+
+    dropped_categories: List[str] = None
+    drop_first: bool = None

--- a/saiph/reduction/mca.py
+++ b/saiph/reduction/mca.py
@@ -27,6 +27,7 @@ def fit(
     df: pd.DataFrame,
     nf: Optional[int] = None,
     col_weights: Optional[NDArray[np.float_]] = None,
+    drop_first: bool = True
 ) -> Model:
     """Fit a MCA model on data.
 
@@ -35,11 +36,12 @@ def fit(
         nf: Number of components to keep. default: min(df.shape)
         col_weights: Weight assigned to each variable in the projection
             (more weight = more importance in the axes). default: np.ones(df.shape[1])
-
+        drop_first: ...
     Returns:
         model: The model for transforming new data.
     """
-    nf = nf or min(pd.get_dummies(df).shape)
+    print('drop_first:', drop_first)
+    nf = nf or min(pd.get_dummies(df, drop_first=drop_first).shape)
 
     _col_weights = col_weights if col_weights is not None else np.ones(df.shape[1])
 
@@ -50,7 +52,10 @@ def fit(
 
     modality_numbers = []
     for column in df.columns:
-        modality_numbers += [len(df[column].unique())]
+        if drop_first:
+            modality_numbers += [len(df[column].unique())-1]
+        else:
+            modality_numbers += [len(df[column].unique())]
 
     col_weights_dummies: NDArray[Any] = np.array(
         list(
@@ -60,12 +65,27 @@ def fit(
         )
     )
 
-    df_scale, _modalities, r, c = center(df)
+
+    df_scale, _modalities, r, c = center(df, drop_first=drop_first)
+
     df_scale, T, D_c = _diag_compute(df_scale, r, c)
 
     # get the array gathering proportion of each modality among individual (N/n)
-    df_dummies = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP)
+    df_dummies_full = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP)
+    df_dummies = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=drop_first)
+    dropped_categories = list(set(df_dummies_full.columns)-set(df_dummies.columns))
+    print('dropped_categories: ', dropped_categories)
+
     dummies_col_prop = len(df_dummies) / df_dummies.sum(axis=0)
+    print('dummies_col_prop: ', dummies_col_prop)
+
+    # print('T:', T.shape)
+    # print('col_weights_dummies:', col_weights_dummies.shape)
+    # print('row_weights:', row_weights.shape)
+
+    # print('T:', T)
+    # print('col_weights_dummies:', col_weights_dummies)
+    # print('row_weights:', row_weights)
 
     # apply the weights and compute the svd
     Z = ((T * col_weights_dummies).T * row_weights).T
@@ -98,6 +118,8 @@ def fit(
         row_weights=row_weights,
         dummies_col_prop=dummies_col_prop,
         modalities_types=modalities_types,
+        drop_first=drop_first,
+        dropped_categories = dropped_categories
     )
 
     return model
@@ -107,7 +129,7 @@ def fit_transform(
     df: pd.DataFrame,
     nf: Optional[int] = None,
     col_weights: Optional[NDArray[np.float_]] = None,
-) -> Tuple[pd.DataFrame, Model]:
+    drop_first: bool = True):
     """Fit a MCA model on data and return transformed data.
 
     Parameters:
@@ -120,13 +142,14 @@ def fit_transform(
         model: The model for transforming new data.
         coord: The transformed data.
     """
-    model = fit(df, nf, col_weights)
+    model = fit(df, nf, col_weights, drop_first)
     coord = transform(df, model)
     return coord, model
 
 
 def center(
     df: pd.DataFrame,
+    drop_first: bool
 ) -> Tuple[pd.DataFrame, NDArray[Any], NDArray[Any], NDArray[Any]]:
     """Center data and compute modalities.
 
@@ -143,7 +166,7 @@ def center(
         row_sum: Sums line by line
         column_sum: Sums column by column
     """
-    df_scale = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP)
+    df_scale = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=drop_first)
     _modalities = df_scale.columns.values
 
     # scale data
@@ -164,7 +187,7 @@ def scaler(model: Model, df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         df_scaled: The scaled DataFrame.
     """
-    df_scaled = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP)
+    df_scaled = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=model.drop_first)
     if model._modalities is not None:
         for mod in model._modalities:
             if mod not in df_scaled:
@@ -174,6 +197,8 @@ def scaler(model: Model, df: pd.DataFrame) -> pd.DataFrame:
     # scale
     df_scaled /= df_scaled.sum().sum()
     df_scaled /= np.array(np.sum(df_scaled, axis=1))[:, None]
+    df_scaled = df_scaled.fillna(0.0) # Needed when drop_first=True
+
     return df_scaled
 
 
@@ -226,7 +251,7 @@ def get_variable_contributions(
         raise ValueError(
             "Model has not been fitted. Call fit() to create a Model instance."
         )
-    df = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP)
+    df = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=model.drop_first)
 
     centered_df = df / df.sum().sum()
 

--- a/saiph/reduction/mca.py
+++ b/saiph/reduction/mca.py
@@ -22,12 +22,30 @@ from saiph.reduction.utils.common import (
 )
 from saiph.reduction.utils.svd import SVD
 
+def dummify(df: pd.DataFrame, drop_first: bool) -> pd.DataFrame:
+    """Dummifies the input data. If drop_first is True, remove one dummy for binomial vars only."""
+    if drop_first:
+        df_dummies = None
+        for c in df.columns:
+            drop = True
+            if len(df[c].unique()) > 2:
+                drop = False
+            tmp = pd.get_dummies(pd.DataFrame(df[c]).astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=drop)
+            if df_dummies is not None:
+                df_dummies = pd.concat([df_dummies, tmp], axis=1)
+            else:
+                df_dummies = tmp.copy()
+    else:
+        df_dummies = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=False)
+    return df_dummies
 
 def fit(
-    df: pd.DataFrame,
+    df: pd.DataFrame,    
     nf: Optional[int] = None,
     col_weights: Optional[NDArray[np.float_]] = None,
-    drop_first: bool = True
+    *,
+    drop_first: bool,
+
 ) -> Model:
     """Fit a MCA model on data.
 
@@ -41,7 +59,8 @@ def fit(
         model: The model for transforming new data.
     """
     print('drop_first:', drop_first)
-    nf = nf or min(pd.get_dummies(df, drop_first=drop_first).shape)
+
+    modality_count = {column: len(df[column].unique()) for column in df.columns}
 
     _col_weights = col_weights if col_weights is not None else np.ones(df.shape[1])
 
@@ -52,10 +71,10 @@ def fit(
 
     modality_numbers = []
     for column in df.columns:
-        if drop_first:
-            modality_numbers += [len(df[column].unique())-1]
+        if drop_first and len(df[column].unique()) <= 2:
+            modality_numbers.append(len(df[column].unique())-1)
         else:
-            modality_numbers += [len(df[column].unique())]
+            modality_numbers.append(len(df[column].unique()))
 
     col_weights_dummies: NDArray[Any] = np.array(
         list(
@@ -65,6 +84,7 @@ def fit(
         )
     )
 
+    nf = nf or min(len(df), sum(modality_numbers))
 
     df_scale, _modalities, r, c = center(df, drop_first=drop_first)
 
@@ -72,20 +92,25 @@ def fit(
 
     # get the array gathering proportion of each modality among individual (N/n)
     df_dummies_full = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP)
-    df_dummies = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=drop_first)
+    df_dummies = dummify(df=df, drop_first=drop_first)
+
+    print('df_dummies_full: ', df_dummies_full)
+    df_dummies_full.to_csv("../dummies.csv", index=False)  
+
+    print('df_dummies: ', len(df_dummies.columns))
+
     dropped_categories = list(set(df_dummies_full.columns)-set(df_dummies.columns))
     print('dropped_categories: ', dropped_categories)
 
     dummies_col_prop = len(df_dummies) / df_dummies.sum(axis=0)
     print('dummies_col_prop: ', dummies_col_prop)
 
-    # print('T:', T.shape)
-    # print('col_weights_dummies:', col_weights_dummies.shape)
-    # print('row_weights:', row_weights.shape)
+    print('T:', T.shape)
+    print('col_weights_dummies:', col_weights_dummies.shape)
+    print('row_weights:', row_weights.shape)
 
-    # print('T:', T)
-    # print('col_weights_dummies:', col_weights_dummies)
-    # print('row_weights:', row_weights)
+    print('T:', T)
+    print('col_weights_dummies:', col_weights_dummies)
 
     # apply the weights and compute the svd
     Z = ((T * col_weights_dummies).T * row_weights).T
@@ -129,7 +154,9 @@ def fit_transform(
     df: pd.DataFrame,
     nf: Optional[int] = None,
     col_weights: Optional[NDArray[np.float_]] = None,
-    drop_first: bool = True):
+    *,
+    drop_first: bool
+   ):
     """Fit a MCA model on data and return transformed data.
 
     Parameters:
@@ -142,7 +169,7 @@ def fit_transform(
         model: The model for transforming new data.
         coord: The transformed data.
     """
-    model = fit(df, nf, col_weights, drop_first)
+    model = fit(df, nf, col_weights, drop_first=drop_first)
     coord = transform(df, model)
     return coord, model
 
@@ -166,7 +193,7 @@ def center(
         row_sum: Sums line by line
         column_sum: Sums column by column
     """
-    df_scale = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=drop_first)
+    df_scale = dummify(df=df, drop_first=drop_first)
     _modalities = df_scale.columns.values
 
     # scale data
@@ -187,7 +214,7 @@ def scaler(model: Model, df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         df_scaled: The scaled DataFrame.
     """
-    df_scaled = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=model.drop_first)
+    df_scaled = dummify(df=df, drop_first=model.drop_first)
     if model._modalities is not None:
         for mod in model._modalities:
             if mod not in df_scaled:
@@ -228,6 +255,7 @@ def transform(df: pd.DataFrame, model: Model) -> pd.DataFrame:
         coord: Coordinates of the dataframe in the fitted space.
     """
     df_scaled = scaler(model, df)
+    print('df_scaled: ', df_scaled)
     coord = df_scaled @ model.D_c @ model.V.T
     coord.columns = get_projected_column_names(model.nf)
     return coord
@@ -251,7 +279,7 @@ def get_variable_contributions(
         raise ValueError(
             "Model has not been fitted. Call fit() to create a Model instance."
         )
-    df = pd.get_dummies(df.astype("category"), prefix_sep=DUMMIES_PREFIX_SEP, drop_first=model.drop_first)
+    df = dummify(df=df, drop_first=model.drop_first)
 
     centered_df = df / df.sum().sum()
 

--- a/saiph/reduction/mca_test.py
+++ b/saiph/reduction/mca_test.py
@@ -245,20 +245,45 @@ def test_get_variable_contributions_sum_is_100_with_col_weights_random_mca(
 
 
 def test_fit_reconstruct() -> None:
+    df = pd.read_csv("/Users/olivier/dev/avatar/core/fixtures/wbcd.csv").astype("category")
+    
     # df = pd.DataFrame(
     #     {
-    #         "tool": ["toaster", "hammer"],
-    #         "score": ["aa", "aa"],
+    #         "tool": ["toaster", "hammer", "hammer", "hammer", "toaster"],
+    #         "score": ["aa", "aa", "bb", "bb", "bb"],
+    #     }
+    # )  # PB !!!
+
+    # df = pd.DataFrame(
+    #     {
+    #         "var1": ["0", "1", "0", "0", "0", "1", "0", "1", "0", "0", "0", "1"],
+    #         # "var1bis": ["1", "0", "1", "1", "1", "0", "1", "0", "1", "1", "1", "0"],
+    #         "score": ["truc", "truc2", "truc3", "truc3", "truc", "truc4", "truc", "truc2", "truc3", "truc3", "truc", "truc4"],
+    #     }
+    # )  # TEST
+
+    # df = pd.DataFrame(
+    #     {
+    #         "var1": ["0", "1", "0", "0", "0", "1"],
+    #         "var1bis": ["1", "0", "1", "1", "1", "0"],
+    #         "score": ["truc", "truc2", "truc3", "truc3", "truc", "truc4"],
     #     }
     # )
 
-    df = pd.DataFrame(
-        {
-            "tool": ["toaster", "hammer", "toaster", "hammer", "toaster", "hammer", "hammer", "mouse", "mouse", "mouse"],
-            "score": ["aa", "aa", "aa", "bb", "aa", "cc", "bb", "cc", "bb", "cc"],
-            "utility": ["zz", "zz", "zz", "yy", "zz", "yy", "yy", "zz", "yy", "zz"],
-        }
-    )
+    # df = pd.DataFrame(
+    #     {
+    #         "tool": ["toaster", "toaster", "hammer", "hammer", "toaster"],
+    #         "score": ["aa", "aa", "bb", "bb", "bb"],
+    #     }
+    # )
+
+    # df = pd.DataFrame(
+    #     {
+    #         "tool": ["toaster", "hammer", "toaster", "hammer", "toaster", "hammer", "hammer", "mouse", "mouse", "mouse"],
+    #         "score": ["aa", "aa", "aa", "bb", "aa", "cc", "bb", "cc", "bb", "cc"],
+    #         "utility": ["zz", "zz", "zz", "yy", "zz", "yy", "yy", "zz", "yy", "zz"],
+    #     }
+    # )
 
     # df = pd.DataFrame(
     #     {
@@ -268,29 +293,29 @@ def test_fit_reconstruct() -> None:
     # )
 
     result, model = fit_transform(df, drop_first=True)
+
     print('result: ', result)
     from saiph.inverse_transform import inverse_transform
 
     from saiph.visualization import plot_circle, plot_var_contribution, plot_projections
     from saiph import stats
-    
 
 
-    # plot_projections(model, df, (0, 1))
+    plot_projections(model, df, (0, 1))
 
     model = stats(model, df)
 
     print('model.contributions:', model.contributions)
     print('model.explained_var:', model.explained_var)
     print('model.explained_var_ratio:', model.explained_var_ratio)
-    # plot_circle(model=model, max_var=10)
+    plot_circle(model=model, max_var=10)
 
-    # plot_var_contribution(
-    # model.contributions["Dim. 1"].to_numpy(), model.contributions.index.to_numpy()
-    # )
-    # plot_var_contribution(
-    # model.contributions["Dim. 2"].to_numpy(), model.contributions.index.to_numpy()
-    # )
+    plot_var_contribution(
+    model.contributions["Dim. 1"].to_numpy(), model.contributions.index.to_numpy()
+    )
+    plot_var_contribution(
+    model.contributions["Dim. 2"].to_numpy(), model.contributions.index.to_numpy()
+    )
 
     inv_trans = inverse_transform(result, model)
     print('inv_trans: ', inv_trans)

--- a/saiph/reduction/pca_test.py
+++ b/saiph/reduction/pca_test.py
@@ -131,3 +131,24 @@ def test_transform_vs_coord() -> None:
     df_transformed = transform(df, model)
 
     assert_frame_equal(coord, df_transformed)
+
+
+def test_dummy_pca() -> None:
+    df = pd.read_csv("~/dev/dummies.csv")
+
+    print('The data:')
+    print(df.head())
+
+    print('dtypes:', df.dtypes)
+    print("PCA with all variables")
+    coord, model = fit_transform(df)
+    print(coord)
+
+    print("PCA after dropping var1___0 ")
+    df = df.drop(columns = ['var1___0'])
+    coord, model = fit_transform(df)
+    print(coord)
+
+    # df_transformed = transform(df, model)
+
+    # assert_frame_equal(coord, df_transformed)

--- a/saiph/visualization.py
+++ b/saiph/visualization.py
@@ -49,7 +49,6 @@ def plot_circle(
         lambda x: abs(x[dimensions[0] - 1]) + abs(x[dimensions[1] - 1]), axis=1
     )
     cor.sort_values(by="sum", ascending=False, inplace=True)
-
     # Plotting arrows
     texts = []
     i = 0


### PR DESCRIPTION
To run the MCA in saiph:
poetry run pytest -rP saiph/reduction/mca_test.py::test_fit_reconstruct

If you want to run it from avatar, you need to set avatar to use the local version of saiph and change the default value of drop_first in the fit function of projections.py. That’s because the drop_first arg is not available in avatar.

Notes: 
- We are able to transform and inverse_transform datasets.
- When used as part of the avatarization, the quality tests show very poor signal retention (e.g. Hellinger > 0.5 instead of a value around 0.05 when keeping all dummies). This was tested on wbcd which only contains 1 bimodal variable 