### PR TITLE
fix: add normalization in get_random_weighted_columns

### DIFF
--- a/saiph/inverse_transform.py
+++ b/saiph/inverse_transform.py
@@ -63,6 +63,7 @@ def inverse_transform(
         model.prop = cast(pd.Series, model.prop)
         descaled_values_quanti = (scaled_values_quanti * model.std) + model.mean
         descaled_values_quali = (scaled_values_quali * np.sqrt(model.prop)) + model.prop
+
         del scaled_values_quali
         del scaled_values_quanti
         undummy = undummify(
@@ -167,8 +168,11 @@ def get_random_weighted_columns(
         column_labels: selected column labels
     """
     # Example for 1 row:  [0.1, 0.3, 0.6] --> [0.1, 0.4, 1.0]
-    cum_probability = df.cumsum(axis=1)
+    # probabilities needs to be normalized before draw
+    normalized_df = df.div(df.sum(axis=1), axis=0)
+    cum_probability = normalized_df.cumsum(axis=1)
     random_probability = random_gen.random((cum_probability.shape[0], 1))
+
     # [0.342] < [0.1, 0.4, 1.0] --> [False, True, True] --> idx: 1
     column_labels = (random_probability < cum_probability).idxmax(axis=1)
 

--- a/saiph/inverse_transform_test.py
+++ b/saiph/inverse_transform_test.py
@@ -32,7 +32,12 @@ def test_get_random_weighted_columns(weights: List[float], expected_index: int) 
 
 
 def test_normalization() -> None:
-    """Verify that the last modality can be sampled when its cumulated sum is greater than 1."""
+    """Verify that the last modality can be sampled when its cumulated sum is greater than 1.
+
+    This test will fail if the values are not normalized first because the last modality would
+    have no chance to be drawn.
+
+    """
     df = pd.DataFrame(data=[[0.5, 0.5, 0.5]])
     result = get_random_weighted_columns(df, np.random.default_rng(4))
     assert result.values[0] == 2

--- a/saiph/inverse_transform_test.py
+++ b/saiph/inverse_transform_test.py
@@ -31,6 +31,13 @@ def test_get_random_weighted_columns(weights: List[float], expected_index: int) 
     assert result.values[0] == expected_index
 
 
+def test_normalization() -> None:
+    """Verify that the last modality can be sampled when its cumulated sum is greater than 1."""
+    df = pd.DataFrame(data=[[0.5, 0.5, 0.5]])
+    result = get_random_weighted_columns(df, np.random.default_rng(4))
+    assert result.values[0] == 2
+
+
 @pytest.mark.parametrize(
     "use_max_modalities, expected",
     [


### PR DESCRIPTION
Adds a normalization step in `get_random_weighted_columns ` (used when the arg `use_max_modalities = False`, which is how it is used in avatar).
Ensures that the max cumsum value is 1 and that all modalities can be sampled.