### PR TITLE
feat: pass np.random.Generator between methods instead of seed

### DIFF
--- a/saiph/inverse_transform.py
+++ b/saiph/inverse_transform.py
@@ -1,6 +1,6 @@
 """Inverse transform coordinates."""
 import ast
-from typing import Dict, List, Optional, cast
+from typing import Dict, List, cast
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,6 @@ def inverse_transform(
     *,
     use_approximate_inverse: bool = False,
     use_max_modalities: bool = True,
-    seed: Optional[int] = None,
 ) -> pd.DataFrame:
     """Return original format dataframe from coordinates.
 
@@ -30,12 +29,13 @@ def inverse_transform(
         use_max_modalities: for each variable, it assigns to the individual
             the modality with the highest proportion (True)
             or a random modality weighted by their proportion (False). default: True
-        seed: seed to fix randomness if use_max_modalities = False. default: None
 
     Returns:
         inverse: coordinates transformed into original space.
             Retains shape, encoding and structure.
     """
+    random_gen = np.random.default_rng(model.seed)
+
     # Check dimension size regarding N
     n_dimensions = len(model.dummy_categorical) + len(model.original_continuous)
     n_records = len(coord)
@@ -70,7 +70,7 @@ def inverse_transform(
             descaled_values_quali,
             get_dummies_mapping(model.original_categorical, model.dummy_categorical),
             use_max_modalities=use_max_modalities,
-            seed=seed,
+            random_gen=random_gen,
         )
         inverse = pd.concat([descaled_values_quanti, undummy], axis=1).round(12)
 
@@ -99,7 +99,7 @@ def inverse_transform(
             descaled_values_quali,
             get_dummies_mapping(model.original_categorical, model.dummy_categorical),
             use_max_modalities=use_max_modalities,
-            seed=seed,
+            random_gen=random_gen,
         )
     # Cast columns to same type as input
     for name, dtype in model.original_dtypes.items():
@@ -122,7 +122,7 @@ def undummify(
     dummies_mapping: Dict[str, List[str]],
     *,
     use_max_modalities: bool = True,
-    seed: Optional[int] = None,
+    random_gen: np.random.Generator = np.random.default_rng(),
 ) -> pd.DataFrame:
     """Return undummified dataframe from the dummy dataframe.
 
@@ -137,7 +137,6 @@ def undummify(
         inverse_quali: undummify df of categorical variable
     """
     inverse_quali = pd.DataFrame()
-    random_gen = np.random.default_rng(seed)
 
     def get_suffix(string: str) -> str:
         return string.split(DUMMIES_PREFIX_SEP)[1]

--- a/saiph/inverse_transform_test.py
+++ b/saiph/inverse_transform_test.py
@@ -69,7 +69,12 @@ def test_undummify(
         columns=["tool___hammer", "tool___wrench", "fruit___apple", "fruit___orange"],
     )
 
-    df = undummify(dummy_df, mapping, use_max_modalities=use_max_modalities, seed=321)
+    df = undummify(
+        dummy_df,
+        mapping,
+        use_max_modalities=use_max_modalities,
+        random_gen=np.random.default_rng(321),
+    )
 
     assert_frame_equal(df, expected)
 
@@ -107,9 +112,9 @@ def test_inverse_transform_with_ponderation() -> None:
         "cont1": 1,
         "cont2": 1,
     }
-    coord, model = fit_transform(df, col_weights=col_weights)
+    coord, model = fit_transform(df, col_weights=col_weights, seed=5)
     result = inverse_transform(
-        coord, model, use_approximate_inverse=True, use_max_modalities=False, seed=46
+        coord, model, use_approximate_inverse=True, use_max_modalities=False
     )
     assert_frame_equal(result, inverse_expected)
 
@@ -132,7 +137,7 @@ def test_inverse_transform_deterministic() -> None:
     }
     coord, model = fit_transform(df, col_weights=col_weights)
     result = inverse_transform(
-        coord, model, use_approximate_inverse=True, use_max_modalities=True, seed=46
+        coord, model, use_approximate_inverse=True, use_max_modalities=True
     )
     assert_frame_equal(result, inverse_expected)
 

--- a/saiph/models.py
+++ b/saiph/models.py
@@ -68,3 +68,5 @@ class Model:
     cos2: Optional[pd.DataFrame] = None
     # Proportion of individuals taking each modality.
     dummies_col_prop: Optional[NDArray[np.float_]] = None  # MCA only
+
+    seed: Optional[int] = None

--- a/saiph/projection_test.py
+++ b/saiph/projection_test.py
@@ -29,7 +29,6 @@ def test_transform_then_inverse_PCA(iris_quanti_df: pd.DataFrame) -> None:
 
 
 def test_transform_then_inverse_MCA(quali_df: pd.DataFrame) -> None:
-
     df = quali_df
     transformed, model = fit_transform(df)
     un_transformed = inverse_transform(transformed, model)
@@ -285,7 +284,7 @@ def test_transform_then_inverse_value_type(dtypes: str) -> None:
     df = df.astype(dtypes)
 
     coord, model = fit_transform(df)
-    result = inverse_transform(coord, model, seed=46)
+    result = inverse_transform(coord, model)
 
     assert_frame_equal(df, result)
 
@@ -405,3 +404,51 @@ def test_fit_checks_col_weights_parameter(
 ) -> None:
     """Verify that fit checks col_weights parameter and fails when it needs to."""
     fit(quali_df, col_weights=col_weights)
+
+
+@pytest.mark.parametrize(
+    "starting_seed, stored_seed",
+    [
+        (1, 2032329982),
+        (np.random.default_rng(1), 2032329982),  # same stored_seed as seed=1
+        (2, 3597359296),  # different than seed=1
+    ],
+)
+def test_fit_pca_works_with_different_arguments_for_seed_and_stores_them_in_model(
+    starting_seed: Any, stored_seed: int
+) -> None:
+    """Verify that fit works with different arguments for seed and stores them in model."""
+    model = fit(df_pca, seed=starting_seed)
+    assert model.seed == stored_seed
+
+
+@pytest.mark.parametrize(
+    "starting_seed, stored_seed",
+    [
+        (1, 2032329982),
+        (np.random.default_rng(1), 2032329982),  # same stored_seed as seed=1
+        (2, 3597359296),  # different than seed=1
+    ],
+)
+def test_fit_famd_works_with_different_arguments_for_seed_and_stores_them_in_model(
+    starting_seed: Any, stored_seed: int
+) -> None:
+    """Verify that fit works with different arguments for seed and stores them in model."""
+    model = fit(df_famd, seed=starting_seed)
+    assert model.seed == stored_seed
+
+
+@pytest.mark.parametrize(
+    "starting_seed, stored_seed",
+    [
+        (1, 2032329982),
+        (np.random.default_rng(1), 2032329982),  # same stored_seed as seed=1
+        (2, 3597359296),  # different than seed=1
+    ],
+)
+def test_fit_mca_works_with_different_arguments_for_seed_and_stores_them_in_model(
+    starting_seed: Any, stored_seed: int
+) -> None:
+    """Verify that fit works with different arguments for seed and stores them in model."""
+    model = fit(df_mca, seed=starting_seed)
+    assert model.seed == stored_seed

--- a/saiph/reduction/famd_sparse.py
+++ b/saiph/reduction/famd_sparse.py
@@ -1,6 +1,6 @@
 """FAMD projection module."""
 import sys
-from typing import Any, List, Optional, Tuple, cast
+from typing import Any, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,7 @@ def fit(
     df: pd.DataFrame,
     nf: Optional[int] = None,
     col_weights: Optional[NDArray[np.float_]] = None,
-    seed: Optional[int] = None,
+    seed: Optional[Union[int, np.random.Generator]] = None,
 ) -> Model:
     """Fit a FAMD model on sparse data.
 
@@ -31,13 +31,17 @@ def fit(
     Returns:
         model: The model for transforming new data.
     """
-    return fit_famd(df, nf, col_weights, center=center_sparse)
+    random_gen = (
+        seed if isinstance(seed, np.random.Generator) else np.random.default_rng(seed)
+    )
+    return fit_famd(df, nf, col_weights, center=center_sparse, seed=random_gen)
 
 
 def fit_transform(
     df: pd.DataFrame,
     nf: Optional[int] = None,
     col_weights: Optional[NDArray[np.float_]] = None,
+    seed: Optional[Union[int, np.random.Generator]] = None,
 ) -> Tuple[pd.DataFrame, Model]:
     """Fit a FAMD model on data and return transformed data.
 
@@ -51,7 +55,11 @@ def fit_transform(
         coord: The transformed data.
         model: The model for transforming new data.
     """
-    model = fit(df, nf, col_weights)
+    random_gen = (
+        seed if isinstance(seed, np.random.Generator) else np.random.default_rng(seed)
+    )
+
+    model = fit(df, nf, col_weights, seed=random_gen)
     coord = transform(df, model)
     return coord, model
 

--- a/saiph/reduction/utils/svd.py
+++ b/saiph/reduction/utils/svd.py
@@ -12,7 +12,7 @@ def get_svd(
     nf: Optional[int] = None,
     *,
     svd_flip: bool = True,
-    seed: Optional[int] = None,
+    random_gen: np.random.Generator = np.random.default_rng(),
 ) -> Tuple[NDArray[np.float_], NDArray[np.float_], NDArray[np.float_]]:
     """Compute Singular Value Decomposition.
 
@@ -33,7 +33,7 @@ def get_svd(
     if nf is not None and nf < 0.8 * np.min(df.shape):
         # Compute a truncated SVD using randomized methods, for faster computations
         U, S, Vt = get_direct_randomized_svd(
-            df, q=2, l_retained_dimensions=nf, seed=seed
+            df, q=2, l_retained_dimensions=nf, random_gen=random_gen
         )
 
     else:
@@ -51,7 +51,7 @@ def get_randomized_subspace_iteration(
     l_retained_dimensions: int,
     *,
     q: int = 2,
-    seed: Optional[int] = None,
+    random_gen: np.random.Generator = np.random.default_rng(),
 ) -> NDArray[np.float_]:
     """Generate a subspace for more efficient SVD computation using random methods.
 
@@ -72,7 +72,6 @@ def get_randomized_subspace_iteration(
         Q: matrix whose range approximates the range of A, shape (m, l)
     """
     m, n = A.shape
-    random_gen = np.random.default_rng(seed=seed)
     omega = random_gen.normal(loc=0, scale=1, size=(n, l_retained_dimensions))
 
     # Initialization
@@ -92,7 +91,7 @@ def get_direct_randomized_svd(
     A: NDArray[np.float_],
     l_retained_dimensions: int,
     q: int = 2,
-    seed: Optional[int] = None,
+    random_gen: np.random.Generator = np.random.default_rng(),
 ) -> Tuple[NDArray[np.float_], NDArray[np.float_], NDArray[np.float_]]:
     """Compute a fixed-rank SVD approximation using random methods.
 
@@ -124,7 +123,7 @@ def get_direct_randomized_svd(
 
     # Q: matrix whose range approximates the range of A, shape (m, l)
     Q = get_randomized_subspace_iteration(
-        A, q=q, l_retained_dimensions=l_retained_dimensions, seed=seed
+        A, q=q, l_retained_dimensions=l_retained_dimensions, random_gen=random_gen
     )
 
     B = Q.transpose() @ A

--- a/saiph/reduction/utils/svd_test.py
+++ b/saiph/reduction/utils/svd_test.py
@@ -41,14 +41,18 @@ def test_full_svd(matrix: pd.DataFrame) -> None:
     )
 
     # Should return a full SVD using scipy implementation
-    U, S, Vt = get_svd(matrix, nf=np.min(pd.get_dummies(matrix).shape), seed=2)
+    U, S, Vt = get_svd(
+        matrix,
+        nf=np.min(pd.get_dummies(matrix).shape),
+        random_gen=np.random.default_rng(2),
+    )
 
     assert_array_almost_equal(U, expected_U, decimal=6)
     assert_array_almost_equal(S, expected_S, decimal=6)
     assert_array_almost_equal(Vt, expected_Vt, decimal=6)
 
     # Should also return a full SVD using scipy implementation
-    U, S, Vt = get_svd(matrix, nf=None, seed=2)
+    U, S, Vt = get_svd(matrix, nf=None, random_gen=np.random.default_rng(2))
 
     assert_array_almost_equal(U, expected_U, decimal=6)
     assert_array_almost_equal(S, expected_S, decimal=6)
@@ -64,7 +68,9 @@ def test_randomized_subspace(matrix: pd.DataFrame) -> None:
         ]
     )
 
-    Q = get_randomized_subspace_iteration(matrix, q=2, l_retained_dimensions=2, seed=2)
+    Q = get_randomized_subspace_iteration(
+        matrix, q=2, l_retained_dimensions=2, random_gen=np.random.default_rng(2)
+    )
 
     assert_array_almost_equal(Q, expected_Q, decimal=6)
 
@@ -81,7 +87,9 @@ def test_direct_randomized_svd(matrix: pd.DataFrame) -> None:
         [[0.47967118, 0.57236779, 0.66506441], [-0.77669099, -0.07568647, 0.62531805]]
     )
 
-    U, S, Vt = get_direct_randomized_svd(matrix, q=2, l_retained_dimensions=2, seed=2)
+    U, S, Vt = get_direct_randomized_svd(
+        matrix, q=2, l_retained_dimensions=2, random_gen=np.random.default_rng(2)
+    )
 
     assert_array_almost_equal(U, expected_U, decimal=6)
     assert_array_almost_equal(S, expected_S, decimal=6)
@@ -98,12 +106,14 @@ def test_randomized_and_full_svd_allclose(matrix: pd.DataFrame) -> None:
 
         # Return a lower-rank=nf randomized SVD
         U_randomized, S_randomized, Vt_randomized = get_direct_randomized_svd(
-            matrix, q=2, l_retained_dimensions=nf, seed=2
+            matrix, q=2, l_retained_dimensions=nf, random_gen=np.random.default_rng(2)
         )
 
         # Compute full-rank=dim(matrix) SVD using scipy implementation, then truncated with to nf
         U_full, S_full, Vt_full = get_svd(
-            matrix, nf=np.min(pd.get_dummies(matrix).shape), seed=2
+            matrix,
+            nf=np.min(pd.get_dummies(matrix).shape),
+            random_gen=np.random.default_rng(2),
         )
         U_full = U_full[:, :nf]
         S_full = S_full[:nf]
@@ -126,7 +136,7 @@ def test_usage_of_randomized_svd(matrix: pd.DataFrame) -> None:
     """Test that `get_svd` returns a randomized svd when nf smaller than dim(matrix).
 
     If this test fail, it could be either:
-    - the randomized SVD comportement has changed;
+    - the randomized SVD behavior has changed;
     - `get_svd` returns a full-rank SVD using `scipy` implementation rather
         than lower-rank randomized SVD.
     """
@@ -141,7 +151,7 @@ def test_usage_of_randomized_svd(matrix: pd.DataFrame) -> None:
     )
 
     # Should return a lower-rank=2 randomized SVD
-    U, S, Vt = get_svd(matrix, nf=2, seed=2)
+    U, S, Vt = get_svd(matrix, nf=2, random_gen=np.random.default_rng(2))
 
     assert_array_almost_equal(U, expected_U, decimal=8)
     assert_array_almost_equal(S, expected_S, decimal=8)


### PR DESCRIPTION
The intention of this PR was mainly to store the provided seed in the model, so that loading and dumping the `Model` would preserve that seed.

It led to various changes, notably that `seed` couldn't be passed in `inverse_transform` anymore, because we now grab it from `model`.

I took the opportunity to go over the codebase and check whether we were handling the seed correctly, which we weren't doing e.g. `famd_sparse::fit` was not passing the seed to `famd::fit`.

From this, I decided to refactor how we are handling seeding, as passing the seed around and fitting a new generator with the same seed multiple times yields the same random sequence, which is not secure. Thus, I decided to also allow passing an instance of `np.random.Generator`, and this instance is created only once at the beginning of the main methods, `fit` and `inverse_transform`.

All the other methods that are not public only allow receiving an instance of `np.random.Generator` e.g. `undummify`.

So, in essence, this PR:

- adds `seed` to `Model`
- passes a single `np.random.Generator` instance around
- removes `seed` from `inverse_transform`

I tested all the changes with `lsg` and `api` as well.