### PR TITLE
fix(saiph): handle df with constant variable

### DIFF
--- a/saiph/reduction/famd_sparse.py
+++ b/saiph/reduction/famd_sparse.py
@@ -96,8 +96,8 @@ def center_sparse(
     mean = np.mean(df_quanti, axis=0)
     df_quanti -= mean
     std = np.std(df_quanti, axis=0)
-    std[std <= sys.float_info.min] = 1
-    df_quanti /= std
+    std_without_zero = np.where(std <= sys.float_info.min, 1, std)
+    df_quanti /= std_without_zero
     df_quanti = csr_matrix(df_quanti)
 
     # scale the categorical data

--- a/saiph/reduction/famd_test.py
+++ b/saiph/reduction/famd_test.py
@@ -257,3 +257,20 @@ def test_get_variable_contributions_sum_is_100_with_col_weights_random_famd(
     contributions, _ = get_variable_contributions(model, mixed_df)
     summed_contributions = contributions.sum(axis=0)
     assert_series_equal(summed_contributions, pd.Series([100.0] * 3), check_index=False)
+
+
+def test_get_variable_contributions_with_constant_variable() -> None:
+    """Ensure it handles a constant variable in the df, hence with a null eigenvalue."""
+    df = pd.DataFrame(
+        {
+            "quantitative_var": [1, 2, 3, 4],
+            "quantitative_constant_var": [1, 1, 1, 1],
+            "qualitative_var": ["a", "b", "c", "d"],
+            "qualitative_constant_var": ["a", "a", "a", "a"],
+        }
+    )
+    _, model = fit_transform(df, nf=None)
+
+    contributions, _ = get_variable_contributions(model, df, explode=False)
+
+    assert np.isfinite(contributions).all().all()

--- a/saiph/reduction/pca_test.py
+++ b/saiph/reduction/pca_test.py
@@ -70,7 +70,9 @@ def test_fit_zero() -> None:
     assert pd.isnull(model.explained_var_ratio).all()
     assert_allclose(model.variable_coord, model.V.T, atol=0.01)
     assert_allclose(model.mean, [1.0, 2.0])
-    assert_allclose(model.std, [1.0, 1.0])
+    assert_allclose(
+        model.std, [0, 0]
+    )  # The standard deviation of a constant variable is zero
 
 
 def test_center_scaler() -> None:

--- a/saiph/visualization.py
+++ b/saiph/visualization.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt  # type: ignore
+from matplotlib.patches import Circle  # type: ignore
 from numpy.typing import NDArray
 
 from saiph import transform
@@ -37,7 +38,7 @@ def plot_circle(
     figure_axis_size = 6
     explained_var_ratio = model.explained_var_ratio
 
-    circle1 = plt.Circle((0, 0), radius=1, color="k", fill=False)
+    circle1 = Circle((0, 0), radius=1, color="k", fill=False)
     fig = plt.gcf()
     fig.set_size_inches(5, 5)
     fig.gca().add_artist(circle1)
@@ -103,7 +104,7 @@ def plot_var_contribution(
     plt.figure(figsize=(12, 6))
     indices = range(len(values))
     plt.bar(indices, values, align="center")
-    plt.xticks(indices, names, rotation="horizontal")
+    plt.xticks(indices, names.astype(str).tolist(), rotation="horizontal")
 
     # setting labels and title
     plt.title(title)
@@ -139,7 +140,7 @@ def plot_explained_var(
     )
     plt.xticks(
         range(len(explained_percentage)),
-        range(1, len(explained_percentage) + 1),
+        [str(i) for i in range(1, len(explained_percentage) + 1)],
         rotation="horizontal",
     )
 


### PR DESCRIPTION
Fixes #128. 

Also, quantitative constant variables now have a std of 0 (previously had 1 to avoid division error, but this is incorrect).

/!\ I presume that the variable contribution of a constant variable should be 0. However, it is **currently not the case**:

```python3
df = pd.DataFrame(
        {
            "quantitative_var": [1, 2, 3, 4],
            "quantitative_constant_var": [1, 1, 1, 1],
            "qualitative_var": ["a", "b", "c", "d"],
            "qualitative_constant_var": ["a", "a", "a", "a"],
        }
    )
    _, model = fit_transform(df, nf=None)
    contributions, _ = get_variable_contributions(model, df, explode=False)

>>> contributions=                                 Dim. 1        Dim. 2        Dim. 3     Dim. 4
quantitative_var           5.000000e+01  3.144382e-30  5.843524e-31  38.275173
quantitative_constant_var  4.618302e-32  3.364274e-32  1.679245e-31   8.525201
qualitative_var            5.000000e+01  1.000000e+02  1.000000e+02  53.199626
qualitative_constant_var   0.000000e+00  0.000000e+00  0.000000e+00   0.000000
```
The contribution quantitative_constant_var is not null for dim4, which should be investigated. It seems that the problem appears when there is a quantitative_constant_var alongside other variables:

```python3
    df = pd.DataFrame(
        {
            "quantitative_var": [1, 2, 3, 4],
            # "quantitative_constant_var": [1, 1, 1, 1],
            "qualitative_var": ["a", "b", "c", "d"],
            "qualitative_constant_var": ["a", "a", "a", "a"],
        }
    )
    _, model = fit_transform(df, nf=None)
    contributions, _ = get_variable_contributions(model, df, explode=False)

>>> contributions=                          Dim. 1        Dim. 2  Dim. 3     Dim. 4
quantitative_var            50.0  2.627293e-32     0.0  34.340041
qualitative_var             50.0  1.000000e+02   100.0  65.659959
qualitative_constant_var     0.0  0.000000e+00     0.0   0.000000
```


```python3
    df = pd.DataFrame(
        {
            "quantitative_var": [1, 2, 3, 4],
            "quantitative_constant_var": [1, 1, 1, 1],
            "qualitative_var": ["a", "b", "c", "d"],
           #  "qualitative_constant_var": ["a", "a", "a", "a"],
        }
    )

>>> contributions=                           Dim. 1        Dim. 2        Dim. 3     Dim. 4
quantitative_var             50.0  1.232595e-30  4.980776e-31  14.620597
quantitative_constant_var     0.0  4.930381e-30  3.966731e-32  64.664497
qualitative_var              50.0  1.000000e+02  1.000000e+02  20.714906
```


Note that it handles only constants in the df:
```python3
df = pd.DataFrame(
        {
            # "quantitative_var": [1, 2, 3, 4],
            "quantitative_constant_var": [1, 1, 1, 1],
            # "qualitative_var": ["a", "b", "c", "d"],
            "qualitative_constant_var": ["a", "a", "a", "a"],
        }
    )
    _, model = fit_transform(df, nf=None)
    contributions, _ = get_variable_contributions(model, df, explode=False)

>>>contributions=                           Dim. 1  Dim. 2
quantitative_constant_var     0.0     0.0
qualitative_constant_var      0.0     0.0
```