### PR TITLE
fix: make _compute_svd writable array compatible with pandas 3.x

### DIFF
--- a/saiph/reduction/famd.py
+++ b/saiph/reduction/famd.py
@@ -475,12 +475,12 @@ def _compute_svd(
     # FIXME: kept this here for legacy, don't know why we were doing it: U, V = V, U
 
     sign = np.sign(np.sum(U))
-    signed_U = column_multiplication(pd.DataFrame(U), sign).values
+    signed_U = column_multiplication(pd.DataFrame(U), sign).to_numpy()
 
     # Divide diagonal values by weights
     min_shape = min(signed_U.shape)
     diagonal = np.diag_indices_from(signed_U[:min_shape, :min_shape])
-    weighted_U = signed_U
+    weighted_U = signed_U.copy()
     weighted_U[diagonal] = np.true_divide(signed_U[diagonal], weights)
 
     eigenvalues = np.power(s, 2)


### PR DESCRIPTION
## Summary

Fixes a `ValueError: assignment destination is read-only` raised in pandas 3.x when computing SVD in the FAMD reduction path.

## Root cause

In pandas 3.x, `DataFrame.values` returns a **read-only** NumPy array (a view into the DataFrame's internal block). The existing code did:

```python
signed_U = column_multiplication(pd.DataFrame(U), sign).values  # read-only in pandas 3.x
weighted_U = signed_U                                            # same reference
weighted_U[diagonal] = np.true_divide(...)                       # ValueError!
```

## Fix

Switch to `.to_numpy()` (same semantics, more explicit intent) and explicitly copy before mutation:

```python
signed_U = column_multiplication(pd.DataFrame(U), sign).to_numpy()
weighted_U = signed_U.copy()                  # writable copy
weighted_U[diagonal] = np.true_divide(...)    # no error
```

## Validation

Verified locally against the avatar monorepo with pandas 3.0.3:
- All saiph transform-related avatar tests pass (`transform_test`, `signal_metrics_test`, etc.)
- `saiph.projection.get_variable_contributions` works correctly