### PR TITLE
ci: add prepare-release workflow with workflow_dispatch trigger

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,73 @@
+name: "Prepare Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      run_tests:
+        description: "Run CI tests before releasing"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  run-saiph-ci:
+    name: Run Saiph CI
+    if: inputs.run_tests
+    uses: ./.github/workflows/saiph-ci.yml
+    secrets: inherit
+
+  prepare-release:
+    name: Prepare Release
+    needs: [run-saiph-ci]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.OCTOBOT_SSH_PRIVATE_KEY }}
+          fetch-depth: 0
+          ref: refs/heads/main
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Install dependencies
+        run: just install-packages
+
+      - name: Configure git user
+        run: |
+          git config --global user.email 'octobot@octopize.io'
+          git config --global user.name 'octopize-bot'
+
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.OCTOBOT_GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Prepare release
+        run: uv run python release.py --bump-type ${{ inputs.bump_type }} --yes

--- a/.github/workflows/saiph-ci.yml
+++ b/.github/workflows/saiph-ci.yml
@@ -1,6 +1,8 @@
 name: "Check PR ci"
 
-on: pull_request
+on:
+  pull_request:
+  workflow_call:
 
 jobs:
   saiph-ci:
@@ -29,7 +31,7 @@ jobs:
       uses: extractions/setup-just@v4
 
     - name: Install dependencies
-      run: uv sync --extra matplotlib --group dev --group doc
+      run: just install-packages
 
     - name: Typecheck
       run: just typecheck

--- a/justfile
+++ b/justfile
@@ -7,6 +7,10 @@ default:
 # Install the stack
 install:
     uvx pre-commit install --hook-type commit-msg
+    just install-packages
+
+# Install packages only (without pre-commit hooks, for CI use)
+install-packages:
     uv sync --extra matplotlib --group dev --group doc
 
 # Prepare a new release of saiph

--- a/release.py
+++ b/release.py
@@ -90,7 +90,7 @@ def get_version_from_file(filename: Path) -> Optional[Match]:  # type: ignore[ty
         return get_version_match(file.read(), KEY_MAPPING[filename])
 
 
-def bump_version(bump_type: BumpType) -> None:
+def bump_version(bump_type: BumpType, yes: bool = False) -> None:
     version = get_version_from_file(PYPROJECT_TOML)
 
     if not version:
@@ -100,11 +100,12 @@ def bump_version(bump_type: BumpType) -> None:
 
     next_version = bump(version, bump_type)
 
-    should_bump = typer.confirm(
-        f"Upgrade version from {current_version} to {next_version}?"
-    )
-    if not should_bump:
-        raise typer.Abort()
+    if not yes:
+        should_bump = typer.confirm(
+            f"Upgrade version from {current_version} to {next_version}?"
+        )
+        if not should_bump:
+            raise typer.Abort()
 
     bump_version_in_file(PYPROJECT_TOML, key="version", bump_type=bump_type)
     bump_version_in_file(INIT_PY, key="__version__", bump_type=bump_type)
@@ -186,7 +187,10 @@ def push() -> None:
             raise typer.Exit(result)
 
 
-def check_preconditions() -> None:
+def check_preconditions(yes: bool = False) -> None:
+    if yes:
+        return
+
     preconditions = [
         "Have you run 'make lci'?",
     ]
@@ -200,6 +204,7 @@ def check_preconditions() -> None:
 @app.command()
 def release(
     bump_type: BumpType =  typer.Option(default=BumpType.PATCH.value),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip all confirmations (for CI use)"),
 ) -> Any:
     proc = subprocess.Popen(
         args=("git", "branch", "--show-current"), stdout=PIPE, text=True
@@ -212,8 +217,8 @@ def release(
         )
         raise typer.Exit(1)
 
-    check_preconditions()
-    bump_version(bump_type)
+    check_preconditions(yes)
+    bump_version(bump_type, yes)
     run_uv_lock()
     commit_and_tag()
     push()


### PR DESCRIPTION
## Summary

Adds a `prepare-release` GitHub Actions workflow that can be triggered manually from the Actions tab to release a new version of saiph.

The workflow:
- Accepts `bump_type` (patch/minor/major) and `run_tests` inputs
- Optionally runs the full CI matrix before releasing
- Checks out `main` via `octopize-bot` SSH key, imports GPG key for signed tags
- Runs `release.py --yes` non-interactively to bump version, commit, tag and push

Supporting changes:
- Added `--yes` flag to `release.py` to skip interactive confirmations in CI
- Added `install-packages` justfile recipe (packages only, no pre-commit hooks)
- Added `workflow_call` trigger to `saiph-ci.yml` so it can be reused by the new workflow

## Validation

- `just lci` passes (142 tests, lint, typecheck, docs all green)