### PR TITLE
fix(famd): align dummies by reindex so non-string modalities encode

### DIFF
--- a/saiph/inverse_transform_test.py
+++ b/saiph/inverse_transform_test.py
@@ -238,3 +238,35 @@ def test_inverse_from_coord_famd(
     assert_series_equal(wbcd_statistics.loc["50%"], reversed_statistics.loc["50%"])
     assert_allclose(wbcd_statistics.loc["75%"], reversed_statistics.loc["75%"], atol=1)
     assert_series_equal(wbcd_statistics.loc["max"], reversed_statistics.loc["max"], atol=1)
+
+
+def test_inverse_transform_preserves_bool_modality_proportions() -> None:
+    """A round-trip must not collapse a bool column onto a single modality.
+
+    This is the user-visible consequence of scaler() failing to one-hot encode
+    non-string modalities: with every dummy zero, undummify() picks essentially
+    the same modality for every individual.  saiph 2.0.10 to 2.0.12 turned a
+    balanced 50/50 bool column into a 98/2 split.
+
+    The 20 % tolerance is loose on purpose — the point is that both modalities
+    survive in roughly their original proportions, not that the round-trip is
+    exact.
+    """
+    n = 50
+    df = pd.DataFrame(
+        {
+            "flag": pd.array([True] * n + [False] * n, dtype=object),
+            # Well-separated per modality, so the projection carries enough
+            # signal for the round-trip to recover the right one.
+            "value": [float(x) for x in range(n)] + [float(x) for x in range(1000, 1000 + n)],
+        }
+    )
+    coord, model = fit_transform(df)
+
+    result = inverse_transform(coord, model)
+
+    counts = result["flag"].value_counts()
+    assert set(counts.index) == {True, False}
+    assert counts[True] == pytest.approx(n, rel=0.2)
+    assert counts[False] == pytest.approx(n, rel=0.2)
+    assert all(isinstance(value, bool) for value in result["flag"])

--- a/saiph/reduction/famd.py
+++ b/saiph/reduction/famd.py
@@ -1,7 +1,6 @@
 """FAMD projection module."""
 
 import sys
-from collections import defaultdict
 from collections.abc import Callable
 from itertools import chain, repeat
 from typing import Any, cast
@@ -240,6 +239,11 @@ def scaler(model: Model, df: pd.DataFrame) -> pd.DataFrame:
             "Expected model to have mean and std attributes,",
             f"got {model.mean} and {model.std} instead.",
         )
+    if model._modalities is None:
+        raise ValueError(
+            "Expected model to have a _modalities attribute to align the dummies on, "
+            "got None instead. Call fit() to create a Model instance."
+        )
     model.prop = cast(pd.Series, model.prop)
 
     df_quanti = df[model.original_continuous]
@@ -251,31 +255,19 @@ def scaler(model: Model, df: pd.DataFrame) -> pd.DataFrame:
     df_quanti = (df_quanti - model.mean) / std_without_zeros
 
     # scale
-    # Attach fit-time categories to each column so that pd.get_dummies emits a
-    # column for every modality seen during fit — including those absent from
-    # this transform batch (they become all-zero columns automatically).
-    # This replaces a one-by-one loop that fragmented the DataFrame block
+    df_quali = pd.get_dummies(
+        df[model.original_categorical].astype("category"),
+        prefix_sep=DUMMIES_SEPARATOR,
+        dtype=np.uint8,
+    )
+    # Align on the fit-time modalities: a modality absent from this batch becomes
+    # an all-zero column, and a category unseen at fit is dropped.
+    # `reindex` builds the result in a single allocation, unlike the one-by-one
+    # `df_quali[mod] = 0` loop it replaces, which fragmented the DataFrame block
     # manager and emitted a PerformanceWarning after 100+ insertions.
-    if model._modalities is not None:
-        col_cats: dict[str, list[str]] = defaultdict(list)
-        for mod in model._modalities:
-            col, _, val = mod.partition(DUMMIES_SEPARATOR)
-            col_cats[col].append(val)
-
-        df_quali = pd.get_dummies(
-            df[model.original_categorical].assign(
-                **{col: pd.Categorical(df[col], categories=cats) for col, cats in col_cats.items()}
-            ),
-            prefix_sep=DUMMIES_SEPARATOR,
-            dtype=np.uint8,
-        )
-    else:
-        df_quali = pd.get_dummies(
-            df[model.original_categorical].astype("category"),
-            prefix_sep=DUMMIES_SEPARATOR,
-            dtype=np.uint8,
-        )
-    df_quali = df_quali[model._modalities]
+    # `fill_value` must be a np.uint8 so that the filled columns keep the dtype
+    # asked of get_dummies instead of being upcast to int64.
+    df_quali = df_quali.reindex(columns=model._modalities, fill_value=np.uint8(0))
     df_quali = (df_quali - model.prop) / np.sqrt(model.prop)
 
     df_scaled = pd.concat([df_quanti, df_quali], axis=1)

--- a/saiph/reduction/famd_test.py
+++ b/saiph/reduction/famd_test.py
@@ -9,6 +9,7 @@ from numpy.typing import NDArray
 from pandas._testing.asserters import assert_series_equal
 from pandas.testing import assert_frame_equal
 
+from saiph.models import Model
 from saiph.reduction import DUMMIES_SEPARATOR
 from saiph.reduction.famd import (
     center,
@@ -398,3 +399,84 @@ def test_transform_novel_category_not_seen_at_fit() -> None:
 
     assert coord.shape == (1, model.nf)
     assert not coord.isnull().any().any()
+
+
+# ---------------------------------------------------------------------------
+# Non-string modality tests
+# ---------------------------------------------------------------------------
+# scaler() must one-hot encode a categorical column whatever the Python type of
+# its values.  Reconstructing the fit-time categories by parsing them out of the
+# dummy column names ("cat___True" -> "True") yields strings, which silently
+# fail to match non-string values such as Python bools or ints: every dummy
+# comes out zero and the individual is projected as if it had no modality at
+# all.  See test_inverse_transform_preserves_bool_modality_proportions for the
+# user-visible consequence.
+# ---------------------------------------------------------------------------
+
+
+def unscale_dummies(model: Model, df_scaled: pd.DataFrame) -> pd.DataFrame:
+    """Undo the centering and scaling scaler() applies to the dummy block.
+
+    Returns the raw 0/1 one-hot values, so a test can assert on the encoding
+    itself rather than on a downstream projection.
+    """
+    prop = cast(pd.Series, model.prop)
+    return (df_scaled[model.dummy_categorical] * np.sqrt(prop) + prop).round(6)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(pd.array([True, False] * 10, dtype=object), id="object_bool"),
+        pytest.param(pd.Series([True, False] * 10), id="native_bool"),
+        pytest.param(pd.Series([True, False] * 10).astype("category"), id="category_bool"),
+        pytest.param(pd.array([1, 2] * 10, dtype=object), id="object_int"),
+        pytest.param(pd.array([1.5, 2.5] * 10, dtype=object), id="object_float"),
+        pytest.param(pd.Series([1, 2] * 10).astype("category"), id="category_int"),
+        pytest.param(pd.array(["a", "b"] * 10, dtype=object), id="object_str"),
+        # Only the first value decides the type recorded in model.modalities_types,
+        # so a column mixing types is where any type-casting scheme breaks down.
+        pytest.param(pd.array([True, "unknown"] * 10, dtype=object), id="mixed_bool_str"),
+        pytest.param(pd.array([1, "a"] * 10, dtype=object), id="mixed_int_str"),
+        pytest.param(pd.array([1, 2.5] * 10, dtype=object), id="mixed_int_float"),
+    ],
+)
+def test_scaler_one_hot_encodes_categories_of_any_value_type(values: Any) -> None:
+    """Every individual must get exactly one hot dummy, for any modality type."""
+    df = pd.DataFrame({"cat": values, "num": [float(i) for i in range(20)]})
+    _, model = fit_transform(df)
+
+    dummies = unscale_dummies(model, scaler(model, df))
+
+    assert_series_equal(
+        dummies.sum(axis=1),
+        pd.Series(1.0, index=df.index),
+        check_names=False,
+    )
+    # The hot dummy must be the one naming this row's own modality. Modality
+    # names come from the category labels pandas derives from the column, which
+    # is not always str(value) — a column mixing ints and floats is homogenised
+    # to float, so the int 1 is labelled "1.0".
+    labels = df["cat"].astype("category").astype(str)
+    expected = [f"cat{DUMMIES_SEPARATOR}{label}" for label in labels]
+    assert list(dummies.idxmax(axis=1)) == expected
+
+
+def test_scaler_encodes_bool_column_identically_to_str_column() -> None:
+    """A bool column and its stringified twin must produce the same encoding.
+
+    Pins the invariant behind the whole family: the dummy block depends on which
+    modality each row holds, not on the Python type used to spell it.
+    """
+    flags = [True, False] * 10
+    num = [float(i) for i in range(20)]
+    df_bool = pd.DataFrame({"cat": pd.array(flags, dtype=object), "num": num})
+    df_str = pd.DataFrame({"cat": [str(flag) for flag in flags], "num": num})
+
+    _, model_bool = fit_transform(df_bool)
+    _, model_str = fit_transform(df_str)
+
+    assert_frame_equal(
+        unscale_dummies(model_bool, scaler(model_bool, df_bool)),
+        unscale_dummies(model_str, scaler(model_str, df_str)),
+    )


### PR DESCRIPTION
Alternative to #196, which fixes the same bug. Same root cause, different fix, and tests that fail without it.

## The bug

`scaler()` rebuilt the fit-time `pd.Categorical` categories by parsing them out of the dummy column names — `"flag___True"` → `"flag"` + `"True"`. Those values are always `str`, so they never matched a column holding non-`str` modalities. `pd.Categorical` produced all-NaN, every dummy came out zero, and the individual was projected as if it held no modality at all.

Reproduced on `main` — a balanced 50/50 object-dtype bool column round-trips to a 98/2 split, with the scaled dummy block flat at `-0.707107`:

```python
df = pd.DataFrame({"flag": pd.array([True] * 50 + [False] * 50, dtype=object),
                   "value": [*map(float, range(50))] + [*map(float, range(1000, 1050))]})
coord, model = fit_transform(df)
inverse_transform(coord, model)["flag"].value_counts()
# main:      {False: 98, True: 2}
# this PR:   {True: 50, False: 50}
```

Introduced by 4cf2dfe (#174), so it affects 2.0.10 through 2.0.12. It is not bool-specific — I confirmed the same all-zero-dummy corruption on object-dtype `int`, object-dtype `float`, native `bool`, `category`-of-`int` and `category`-of-`bool` columns.

## The fix

Reconstructing a value from its own string rendering is lossy by nature, so this drops the round-trip rather than casting it back: keep `astype("category")` and align the dummy frame on `model._modalities` with `reindex`.

```python
df_quali = pd.get_dummies(
    df[model.original_categorical].astype("category"),
    prefix_sep=DUMMIES_SEPARATOR,
    dtype=np.uint8,
)
df_quali = df_quali.reindex(columns=model._modalities, fill_value=np.uint8(0))
```

Absent modalities become all-zero columns and categories unseen at fit are dropped, exactly as before — no value ever leaves its original type, so there is nothing to cast and no type to guess. Net 12 lines removed from `scaler()`.

Three details worth calling out:

- **`reindex` allocates once**, so this preserves what #174 was actually for: no block-manager fragmentation `PerformanceWarning` from the old `df_quali[mod] = 0` loop. The existing regression test (`test_transform_famd_absent_categories_no_performance_warning`, 150 modalities under `filterwarnings = ["error"]`) still passes.
- **`fill_value` is `np.uint8(0)`, not `0`.** With a plain `0`, pandas upcasts the filled columns to `int64` — a 100k-row batch missing 180 of 200 modalities held 146 MB instead of 20 MB, and the reindex itself was 10× slower.
- **It no longer depends on `model.modalities_types`**, which records only the type of the *first* value (`get_modalities_types` → `df.loc[0, col]`) and so cannot describe a column with mixed value types.

## Why not the type-casting approach in #196

#196 casts the parsed strings back using `model.modalities_types`. That fixes the common cases, but because the recorded type comes from the first value only, a column mixing types takes the wrong branch for all of its categories and now raises where `main` merely returned wrong numbers:

| input column | `main` | #196 | this PR |
|---|---|---|---|
| `[True, "unknown", …]` | all-zero dummies | `ValueError: Categorical categories cannot be null` | correct |
| `[1, "a", …]` | all-zero dummies | `ValueError: Unable to parse string "a" at position 2` | correct |

`inverse_transform.py:92-93` already documents mixed object columns as a known reality, so this isn't theoretical. Both raise from `fit_transform`, so a dataset that used to process would hard-fail.

## Tests

`test_scaler_one_hot_encodes_categories_of_any_value_type` asserts on the encoding itself — exactly one hot dummy per individual, and that the hot one names that row's own modality — rather than on a downstream projection. It is parametrized over 10 column types, including the three mixed-type columns. `unscale_dummies` undoes the centering/scaling so the raw one-hot values can be asserted directly.

Two supporting tests: `test_scaler_encodes_bool_column_identically_to_str_column` pins the invariant behind the family (the encoding depends on which modality a row holds, not on the Python type used to spell it), and `test_inverse_transform_preserves_bool_modality_proportions` covers the user-visible symptom.

I checked these fail without the fix, by reverting only `famd.py` to `main` and keeping the tests:

| `famd.py` version | result |
|---|---|
| `main` | **11 failed**, 1 passed |
| #196 | **2 failed**, 10 passed |
| this PR | 12 passed |

The single test that passes on `main` is the `object_str` case — strings were never broken, which is the expected signal. The two that fail against #196 are the mixed-type columns in the table above.

Full suite: 156 passed, 1 skipped. `ruff check`, `ruff format --check` and `mypy` clean. (`saiph/tests/benchmark_test.py` fails on `main` too, from a `pytest-benchmark` teardown warning — unrelated.)

## Performance

Measured at 20k rows × 4 categorical columns, 200 modalities, per `scaler()` call:

| batch | `main` | #196 | this PR |
|---|---|---|---|
| all 200 modalities present | 18.8 ms / 128 MB peak | 16.8 ms / 128 MB | **11.6 ms / 68 MB** |
| 180 of 200 absent | 14.4 ms / 128 MB | **12.2 ms / 128 MB** | 20.7 ms / 129 MB |

An honest trade, not a clean win: faster and roughly half the peak memory when most modalities are present, ~1.7× slower on a batch that uses only 5 of 50 categories per column, since `get_dummies` then emits a narrow frame that `reindex` has to widen. I have not profiled a real avatar workload to establish which regime its call sites sit in, so treat the sparse-batch number as the one to watch. Happy to optimise it if you'd rather not take the trade.

## Verified against avatar

Avatar hands saiph **`object`-dtype columns holding Python `bool` values** — I instrumented `saiph.fit` during avatar's own bool tests and every call arrived as `dtype=object` with `modalities_types={"a": "bool"}`. So this is live in production today on the locked `saiph==2.0.12`, not a theoretical path.

**This is octopize/avatar#6321.** That issue diagnoses the same root cause from the pandas side and recommends "Option A — reindex the dummies" as the fix, including the caveat that the fill must keep `uint8`. This PR is that recommendation. I found the issue only after writing the patch, so the agreement is independent.

Avatar's `pyproject.toml` currently silences the symptom:

```toml
# pandas 3 warns (future-raise) when a Categorical is built with values outside
# its dtype's categories, which saiph's FAMD transform does intentionally.
# Temporary until saiph is fixed and the pin bumped -- see issue #6321.
"ignore:Constructing a Categorical with a dtype and values ... not in that dtype's categories:pandas.errors.Pandas4Warning",
```

The "intentionally" in that comment is the bug, not a design choice: pandas was reporting precisely the mismatch that zeroes the dummies. On pandas 3.0.3, `pd.Categorical(pd.array([True, False], dtype=object), categories=["True", "False"])` emits that warning and yields codes `{-1}` — no value matched.

Removing the filter and running avatar's full suite (1055 tests):

| saiph | `#6321` filter removed |
|---|---|
| released 2.0.12 | **19 failed** — 15 genuine `Pandas4Warning` errors + 4 environmental |
| this PR | **4 failed** — the 4 environmental only |

So this unblocks #6321: bump the floor and the workaround can go. (The 4 constants are `report_with_pdfgenerator_test`, whose module is `pytest.mark.needs_reportgenerator`; that binary is not built in my checkout and they fail identically on both.)

**No regressions.** With the filter left in place, a clean run of avatar's full suite is byte-identical between released 2.0.12 and this branch — 4 failed / 1046 passed / 5 skipped / 4 xfailed / 1 xpassed both ways.

**Avatar's existing tests do not detect the bug.** All four bool tests, including `test_avatarize_bool_regression_preserves_both_modalities_with_bool_schema`, pass on the buggy 2.0.12 — so #196's citation of that test as evidence is not load-bearing. The test asserts only that both modalities are *present*, which survives the corruption.

What the corruption actually does, on that test's own dataset (`True` rows have `b` in [1,10], `False` rows have `b` in [20,29]), run through avatar's real avatarize pipeline across 8 seeds:

| saiph | modality counts | mean `b` per modality | bool↔continuous link |
|---|---|---|---|
| released 2.0.12 | 5/15 to 10/10 | `True`≈23.5, `False`≈10.2 | **inverted in 8/8 seeds** |
| this PR | 10/10 in 8/8 | `True`≈5.4, `False`≈24.5 | preserved in 8/8 seeds |

The avatars come out with the boolean flag *anti-correlated* with the continuous variable it was correlated with in the input. That is a silent utility/signal defect in delivered data, which is why I'd treat this as more than a tidy-up.

## Not fixed here

Native `bool`-dtype columns are still broken end-to-end, and this is pre-existing on `main`. Because `original_dtypes` is `bool` rather than `object`/`category`, `inverse_transform.py:94` skips the bool branch and falls through to `.astype(bool)` on the string `"False"` — which is truthy. A 10/10 native-bool column round-trips to `{True: 20}` on `main`, on #196 and on this branch. `scaler()` is fixed here; the inverse side needs its own change. Let me know if you want it in scope.

