### PR TITLE
ci: configure stale bot per SOP-REQ-001

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+name: "ci - Configure stale issues and PRs"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # SOP-REQ-001 §10 — issues with no activity for 90 days and no milestone are labeled
+      # `Stale`. Issues and PRs are never auto-closed, only labeled/commented on.
+      - name: Mark stale
+        uses: actions/stale@v10.4.0
+        with:
+          days-before-issue-stale: 90
+          days-before-pr-stale: 10
+          days-before-issue-close: -1
+          days-before-pr-close: -1
+          exempt-all-milestones: true
+          stale-issue-label: "Stale"
+          stale-pr-label: "Stale"
+          stale-issue-message: >
+            This issue has had no activity for 90 days and has no milestone, so it has been
+            labeled `Stale` per the Avatar GxP periodic-review policy (SOP-REQ-001 §10). If it
+            remains inactive for 30 more days, it will be labeled `stale-need-review` for the
+            Product Owner to reactivate or close. Comment or attach a milestone to keep it active.
+          stale-pr-message: >
+            This PR has had no activity for 10 days, so it has been labeled `Stale`.
+            Comment or push to keep it active — it will not be closed automatically.
+          remove-stale-when-updated: true
+
+      # SOP-REQ-001 §10 — after 30 more days of inactivity on an already-`Stale` issue,
+      # flag it for PO review instead of auto-closing. PRs are not touched by this step.
+      - name: Flag stale issues for PO review
+        uses: actions/stale@v10.4.0
+        with:
+          only-issue-labels: "Stale"
+          days-before-issue-stale: 30
+          days-before-pr-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-close: -1
+          exempt-all-milestones: true
+          stale-issue-label: "stale-need-review"
+          stale-issue-message: >
+            This issue has been `Stale` for 30+ days with no further activity. The Product
+            Owner should review it per SOP-REQ-001 §10: reactivate it or close it as `wontfix`.
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Summary
Applies the same stale-issue policy as octopize/avatar#6668 (SOP-REQ-001 §10) to this repo:
- Issues with no activity for 90 days and no milestone → labeled `Stale`.
- After 30 more days of inactivity on a `Stale` issue → labeled `stale-need-review` for PO review.
- **Neither issues nor PRs are auto-closed** — the bot only labels/comments; closure is a manual PO decision (`wontfix`).
- Created the `Stale` and `stale-need-review` labels (neither existed in this repo before).

## Test plan
- [ ] Trigger the workflow manually (`workflow_dispatch`) against a test issue/PR
- [ ] Confirm issues with a milestone are skipped
- [ ] Confirm the bot never closes anything